### PR TITLE
PR 2: Parse .env file and validate required keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Config Validator CLI
-
 A simple Go-based CLI to validate `.env` or `.yaml` config files.
 
 ## Usage
-
-```bash
 go run . validate --config=.env --json

--- a/SAMPLE.env
+++ b/SAMPLE.env
@@ -1,1 +1,3 @@
-echo DB_HOST=localhost
+PORT=8080
+DB_HOST=localhost
+# DEBUG is intentionally missing for testing

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,28 +1,58 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+
+	"config-validator-cli/core"
 
 	"github.com/spf13/cobra"
 )
 
-func NewValidateCommand() *cobra.Command {
-	var (
-		configPath string
-		jsonOutput bool
-	)
+var configFile string
+var jsonOutput bool
 
+func NewValidateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validate",
 		Short: "Validate a .env or .yaml config file",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println("✅ Running config validation...")
-			fmt.Printf("📁 Config file: %s\n", configPath)
+			fmt.Printf("📁 Config file: %s\n", configFile)
 			fmt.Printf("📤 JSON output: %v\n", jsonOutput)
+
+			// Parse the .env file
+			env, err := core.ParseEnvFile(configFile)
+			if err != nil {
+				fmt.Println("❌ Error reading config file:", err)
+				return
+			}
+
+			// Check required keys
+			missing := core.CheckRequiredKeys(env, core.RequiredKeys)
+
+			if jsonOutput {
+				// Output result in JSON
+				json.NewEncoder(os.Stdout).Encode(map[string]interface{}{
+					"missing_keys": missing,
+					"status":       len(missing) == 0,
+				})
+			} else {
+				// Output in plain text
+				if len(missing) == 0 {
+					fmt.Println("✅ All required keys are present.")
+				} else {
+					fmt.Println("❌ Missing required keys:")
+					for _, key := range missing {
+						fmt.Println("  -", key)
+					}
+				}
+			}
 		},
 	}
 
-	cmd.Flags().StringVar(&configPath, "config", ".env", "Path to config file")
+	cmd.Flags().StringVar(&configFile, "config", ".env", "Path to config file")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Enable JSON output")
 
 	return cmd

--- a/core/checker.go
+++ b/core/checker.go
@@ -1,0 +1,13 @@
+package core
+
+func CheckRequiredKeys(env map[string]string, required []string) []string {
+	var missing []string
+
+	for _, key := range required {
+		if _, exists := env[key]; !exists {
+			missing = append(missing, key)
+		}
+	}
+
+	return missing
+}

--- a/core/parser.go
+++ b/core/parser.go
@@ -1,0 +1,39 @@
+package core
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+func ParseEnvFile(path string) (map[string]string, error) {
+	env := make(map[string]string)
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Ignore comments and empty lines
+		if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		// Parse key=value
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		env[key] = value
+	}
+
+	return env, scanner.Err()
+}

--- a/core/required.go
+++ b/core/required.go
@@ -1,0 +1,8 @@
+package core
+
+// RequiredKeys defines the list of env vars that must be present
+var RequiredKeys = []string{
+	"PORT",
+	"DB_HOST",
+	"DEBUG",
+}


### PR DESCRIPTION
This PR adds support for parsing a `.env` config file and validating required environment variables.

**Key Features:**
- `core/parser.go`: Parses key=value pairs from the config
- `core/checker.go`: Validates required keys
- `core/required.go`: Stores required key list
- Integrated with Cobra CLI
- JSON and plain text output supported

Tested using `sample.env`, CLI outputs correct status and missing keys.

@coolwednesday Looking forward to feedback before continuing to type validation in PR #3!
