### PR TITLE
PR 3: Type-checking for int, bool, and duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Config Validator CLI
-
 A simple Go-based CLI to validate `.env` or `.yaml` config files.
 
 ## Usage
-
-```bash
 go run . validate --config=.env --json

--- a/SAMPLE.env
+++ b/SAMPLE.env
@@ -1,3 +1,4 @@
-PORT=8080
+PORT=abc
 DB_HOST=localhost
-# DEBUG is intentionally missing for testing
+DEBUG=maybe
+TIMEOUT=invalid

--- a/SAMPLE.env
+++ b/SAMPLE.env
@@ -1,1 +1,3 @@
-echo DB_HOST=localhost
+PORT=8080
+DB_HOST=localhost
+# DEBUG is intentionally missing for testing

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,28 +1,58 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+
+	"config-validator-cli/core"
 
 	"github.com/spf13/cobra"
 )
 
-func NewValidateCommand() *cobra.Command {
-	var (
-		configPath string
-		jsonOutput bool
-	)
+var configFile string
+var jsonOutput bool
 
+func NewValidateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validate",
 		Short: "Validate a .env or .yaml config file",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println("✅ Running config validation...")
-			fmt.Printf("📁 Config file: %s\n", configPath)
+			fmt.Printf("📁 Config file: %s\n", configFile)
 			fmt.Printf("📤 JSON output: %v\n", jsonOutput)
+
+			// Parse the .env file
+			env, err := core.ParseEnvFile(configFile)
+			if err != nil {
+				fmt.Println("❌ Error reading config file:", err)
+				return
+			}
+
+			// Check required keys
+			missing := core.CheckRequiredKeys(env, core.RequiredKeys)
+
+			if jsonOutput {
+				// Output result in JSON
+				json.NewEncoder(os.Stdout).Encode(map[string]interface{}{
+					"missing_keys": missing,
+					"status":       len(missing) == 0,
+				})
+			} else {
+				// Output in plain text
+				if len(missing) == 0 {
+					fmt.Println("✅ All required keys are present.")
+				} else {
+					fmt.Println("❌ Missing required keys:")
+					for _, key := range missing {
+						fmt.Println("  -", key)
+					}
+				}
+			}
 		},
 	}
 
-	cmd.Flags().StringVar(&configPath, "config", ".env", "Path to config file")
+	cmd.Flags().StringVar(&configFile, "config", ".env", "Path to config file")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Enable JSON output")
 
 	return cmd

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -22,31 +22,40 @@ func NewValidateCommand() *cobra.Command {
 			fmt.Printf("📁 Config file: %s\n", configFile)
 			fmt.Printf("📤 JSON output: %v\n", jsonOutput)
 
-			// Parse the .env file
 			env, err := core.ParseEnvFile(configFile)
 			if err != nil {
 				fmt.Println("❌ Error reading config file:", err)
 				return
 			}
 
-			// Check required keys
 			missing := core.CheckRequiredKeys(env, core.RequiredKeys)
+			typeErrors := core.ValidateTypes(env)
 
+			// Output result
 			if jsonOutput {
-				// Output result in JSON
-				json.NewEncoder(os.Stdout).Encode(map[string]interface{}{
+				output := map[string]interface{}{
 					"missing_keys": missing,
-					"status":       len(missing) == 0,
-				})
+					"type_errors":  typeErrors,
+					"status":       len(missing) == 0 && len(typeErrors) == 0,
+				}
+				json.NewEncoder(os.Stdout).Encode(output)
 			} else {
-				// Output in plain text
-				if len(missing) == 0 {
-					fmt.Println("✅ All required keys are present.")
-				} else {
+				if len(missing) > 0 {
 					fmt.Println("❌ Missing required keys:")
 					for _, key := range missing {
-						fmt.Println("  -", key)
+						fmt.Printf("  - %s\n", key)
 					}
+				}
+
+				if len(typeErrors) > 0 {
+					fmt.Println("⚠️  Type validation errors:")
+					for _, err := range typeErrors {
+						fmt.Printf("  - %s: %s\n", err.Key, err.Error)
+					}
+				}
+
+				if len(missing) == 0 && len(typeErrors) == 0 {
+					fmt.Println("✅ All required keys and types are valid.")
 				}
 			}
 		},

--- a/core/checker.go
+++ b/core/checker.go
@@ -1,0 +1,13 @@
+package core
+
+func CheckRequiredKeys(env map[string]string, required []string) []string {
+	var missing []string
+
+	for _, key := range required {
+		if _, exists := env[key]; !exists {
+			missing = append(missing, key)
+		}
+	}
+
+	return missing
+}

--- a/core/parser.go
+++ b/core/parser.go
@@ -1,0 +1,39 @@
+package core
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+func ParseEnvFile(path string) (map[string]string, error) {
+	env := make(map[string]string)
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Ignore comments and empty lines
+		if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		// Parse key=value
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		env[key] = value
+	}
+
+	return env, scanner.Err()
+}

--- a/core/required.go
+++ b/core/required.go
@@ -1,0 +1,8 @@
+package core
+
+// RequiredKeys defines the list of env vars that must be present
+var RequiredKeys = []string{
+	"PORT",
+	"DB_HOST",
+	"DEBUG",
+}

--- a/core/typecheck.go
+++ b/core/typecheck.go
@@ -1,0 +1,49 @@
+package core
+
+import (
+	"strconv"
+	"time"
+)
+
+// ValidationError holds key and error reason
+type ValidationError struct {
+	Key   string `json:"key"`
+	Error string `json:"error"`
+}
+
+// ValidateTypes checks if certain env vars match expected types
+func ValidateTypes(env map[string]string) []ValidationError {
+	var errors []ValidationError
+
+	// PORT must be an integer
+	if val, ok := env["PORT"]; ok {
+		if _, err := strconv.Atoi(val); err != nil {
+			errors = append(errors, ValidationError{
+				Key:   "PORT",
+				Error: "must be an integer",
+			})
+		}
+	}
+
+	// DEBUG must be a boolean
+	if val, ok := env["DEBUG"]; ok {
+		if val != "true" && val != "false" {
+			errors = append(errors, ValidationError{
+				Key:   "DEBUG",
+				Error: "must be 'true' or 'false'",
+			})
+		}
+	}
+
+	// TIMEOUT must be a valid duration (e.g., 5s, 1m)
+	if val, ok := env["TIMEOUT"]; ok {
+		if _, err := time.ParseDuration(val); err != nil {
+			errors = append(errors, ValidationError{
+				Key:   "TIMEOUT",
+				Error: "must be a valid duration (e.g. 5s, 1m)",
+			})
+		}
+	}
+
+	return errors
+}


### PR DESCRIPTION
This PR adds type-checking logic to the config validator CLI.

 **Validations included:**
- `PORT` must be an integer
- `DEBUG` must be `true` or `false`
- `TIMEOUT` must be a valid Go-style duration (e.g. `5s`, `2m`)

**New file:**
- `core/typer.go` — validates env values and returns detailed errors

**Output:**
Includes both plain and JSON error reporting for type mismatches.

Looking forward to your feedback ,If you thing there an be any improvements.
