### PR TITLE
PR 3: Type checking for int, bool, and duration

### DIFF
--- a/SAMPLE.env
+++ b/SAMPLE.env
@@ -1,3 +1,4 @@
-PORT=8080
+PORT=abc
 DB_HOST=localhost
-# DEBUG is intentionally missing for testing
+DEBUG=maybe
+TIMEOUT=invalid

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -22,31 +22,40 @@ func NewValidateCommand() *cobra.Command {
 			fmt.Printf("📁 Config file: %s\n", configFile)
 			fmt.Printf("📤 JSON output: %v\n", jsonOutput)
 
-			// Parse the .env file
 			env, err := core.ParseEnvFile(configFile)
 			if err != nil {
 				fmt.Println("❌ Error reading config file:", err)
 				return
 			}
 
-			// Check required keys
 			missing := core.CheckRequiredKeys(env, core.RequiredKeys)
+			typeErrors := core.ValidateTypes(env)
 
+			// Output result
 			if jsonOutput {
-				// Output result in JSON
-				json.NewEncoder(os.Stdout).Encode(map[string]interface{}{
+				output := map[string]interface{}{
 					"missing_keys": missing,
-					"status":       len(missing) == 0,
-				})
+					"type_errors":  typeErrors,
+					"status":       len(missing) == 0 && len(typeErrors) == 0,
+				}
+				json.NewEncoder(os.Stdout).Encode(output)
 			} else {
-				// Output in plain text
-				if len(missing) == 0 {
-					fmt.Println("✅ All required keys are present.")
-				} else {
+				if len(missing) > 0 {
 					fmt.Println("❌ Missing required keys:")
 					for _, key := range missing {
-						fmt.Println("  -", key)
+						fmt.Printf("  - %s\n", key)
 					}
+				}
+
+				if len(typeErrors) > 0 {
+					fmt.Println("⚠️  Type validation errors:")
+					for _, err := range typeErrors {
+						fmt.Printf("  - %s: %s\n", err.Key, err.Error)
+					}
+				}
+
+				if len(missing) == 0 && len(typeErrors) == 0 {
+					fmt.Println("✅ All required keys and types are valid.")
 				}
 			}
 		},

--- a/core/typecheck.go
+++ b/core/typecheck.go
@@ -1,0 +1,49 @@
+package core
+
+import (
+	"strconv"
+	"time"
+)
+
+// ValidationError holds key and error reason
+type ValidationError struct {
+	Key   string `json:"key"`
+	Error string `json:"error"`
+}
+
+// ValidateTypes checks if certain env vars match expected types
+func ValidateTypes(env map[string]string) []ValidationError {
+	var errors []ValidationError
+
+	// PORT must be an integer
+	if val, ok := env["PORT"]; ok {
+		if _, err := strconv.Atoi(val); err != nil {
+			errors = append(errors, ValidationError{
+				Key:   "PORT",
+				Error: "must be an integer",
+			})
+		}
+	}
+
+	// DEBUG must be a boolean
+	if val, ok := env["DEBUG"]; ok {
+		if val != "true" && val != "false" {
+			errors = append(errors, ValidationError{
+				Key:   "DEBUG",
+				Error: "must be 'true' or 'false'",
+			})
+		}
+	}
+
+	// TIMEOUT must be a valid duration (e.g., 5s, 1m)
+	if val, ok := env["TIMEOUT"]; ok {
+		if _, err := time.ParseDuration(val); err != nil {
+			errors = append(errors, ValidationError{
+				Key:   "TIMEOUT",
+				Error: "must be a valid duration (e.g. 5s, 1m)",
+			})
+		}
+	}
+
+	return errors
+}


### PR DESCRIPTION
This PR adds type-checking logic to the config validator CLI.

**Type validations:**
- `PORT`: must be an integer
- `DEBUG`: must be `true` or `false`
- `TIMEOUT`: must be a valid duration (e.g., 5s, 1m)

**Updates:**
- Added `core/typer.go` to hold all type logic
- Integrated into the existing `validate` command
- JSON and plain output both supported

**Sample Output:**
```json
{
  "missing_keys": null,
  "status": false,
  "type_errors": [
    { "key": "PORT", "error": "must be an integer" },
    { "key": "DEBUG", "error": "must be 'true' or 'false'" },
    { "key": "TIMEOUT", "error": "must be a valid duration (e.g. 5s, 1m)" }
  ]
}
